### PR TITLE
feat: native methods to custom components in UI

### DIFF
--- a/src/components/basicComponents/button.tsx
+++ b/src/components/basicComponents/button.tsx
@@ -1,13 +1,23 @@
+import React from 'react';
 import style from './button.module.css';
 
 interface ButtonProps {
-  buttonText: string;
+  attributes: React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  >;
+  children?: React.ReactNode;
 }
 
-export const Button = ({ buttonText }: ButtonProps) => {
+export const Button = ({ attributes, children }: ButtonProps) => {
+  const { onClick, className, type } = attributes;
   return (
-    <button className={style.button} type="submit">
-      {buttonText}
+    <button
+      onClick={onClick}
+      className={className ? `${style.button} ${className}` : style.button}
+      type={type ? 'submit' : 'button'}
+    >
+      {children}
     </button>
   );
 };

--- a/src/components/basicComponents/textInput.tsx
+++ b/src/components/basicComponents/textInput.tsx
@@ -1,9 +1,24 @@
+import React from 'react';
 import style from './textInput.module.css';
 
 interface TextInputProps {
-  placeholder: string;
+  attributes: React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  >;
 }
 
-export const TextInput = ({ placeholder }: TextInputProps) => {
-  return <input className={style.input} type="text" placeholder={placeholder} />;
+export const TextInput = ({ attributes }: TextInputProps) => {
+  const { onChange, placeholder, className, type, disabled, value } = attributes;
+
+  return (
+    <input
+      className={className ? `${style.input} ${className}` : style.input}
+      type={type}
+      disabled={disabled}
+      placeholder={placeholder}
+      onChange={onChange}
+      value={value}
+    />
+  );
 };

--- a/src/components/startPage/StartPage.tsx
+++ b/src/components/startPage/StartPage.tsx
@@ -9,8 +9,8 @@ export const StartPage = () => {
         <div className={style.startTable}>
           <div className={style.separator}>OR</div>
           <div className={style.form}>
-            <TextInput placeholder="Room ID" />
-            <Button buttonText="Join" />
+            <TextInput attributes={{ placeholder: 'Room ID' }} />
+            <Button attributes={{}}>Join</Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Изменил кастомные компоненты. 
При их создании можно обратиться к нативным методам, при помощи передачи пропса attributes и двойной деструктуризации: "attributes"={{}}
По дефолту у кастомного button'a type='button'.  Не могу передать в него переменную из-за линтера.